### PR TITLE
Fix constant name in midi_time_code()

### DIFF
--- a/mxm/midifile/src/midi_outfile.py
+++ b/mxm/midifile/src/midi_outfile.py
@@ -184,7 +184,7 @@ class MidiOutFile(MidiEvents):
         """
         super().midi_time_code(msg_type, values)
         value = (msg_type<<4) + values
-        self.event_slice([c.MIDI_TIME_CODE, value])
+        self.event_slice([c.MTC, value])
 
 
     def song_position_pointer(self, value):


### PR DESCRIPTION
Same fix as in https://github.com/OFAI/python-midi/issues/1. Thanks to @iliTheFallen for reporting it, and @mgrachten for pointing to your repository.